### PR TITLE
Support Podium v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ app.register({
 ## Request params
 
 On each request [@podium/layout] will run a set of operations on the request and
-create a [incoming] object. The [incoming] object is stored at
-`request.app.podium` which is accessible inside request handelers.
+create an [incoming] object. The [incoming] object is stored at
+`request.app.podium` which is accessible inside request handlers.
 
 ```js
 app.route({
@@ -103,8 +103,8 @@ extension.
 
 ## h.podiumSend(fragment)
 
-This method will wrap the provided fragment in a default [document template]
-before dispatching.
+This method will wrap the given fragment in a default [document template] before
+dispatching.
 
 See [document template] for further information.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Build a simple layout server including a single podlet:
 ```js
 const HapiLayout = require('@podium/hapi-layout');
 const Layout = require('@podium/layout');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const app = Hapi.Server({
     host: 'localhost',
@@ -52,12 +52,11 @@ app.register({
 
 app.route({
     method: 'GET',
-    path: '/',
+    path: layout.pathname(),
     handler: (request, h) => {
-        const ctx = request.app.podium.context;
-        return Promise.all([podlet.fetch(ctx)]).then((result) => {
-            return `<html><body>${result[0]}</body></html>`
-        });
+        const incoming = request.app.podium;
+        const result = await podlet.fetch(incoming);
+        return h.podiumSend(result.content);
     },
 });
 
@@ -79,17 +78,18 @@ app.register({
 
 ## Request params
 
-On each request [@podium/layout] will run a set of operations, such as the
-[@podium/context] parsers, on the request. When doing so [@podium/layout] will
-write parameters to `request.app.podium` which is accessible inside a request
-handelers.
+On each request [@podium/layout] will run a set of operations on the request and
+create a [incoming] object. The [incoming] object is stored at
+`request.app.podium` which is accessible inside request handelers.
 
 ```js
 app.route({
     method: 'GET',
     path: '/',
     handler: (request, h) => {
-        return request.app.podium.context;
+        const incoming = request.app.podium;
+        const result = await podlet.fetch(incoming);
+        return h.podiumSend(result.content);
     },
 });
 ```
@@ -100,6 +100,13 @@ setting an object at `request.app.params`.
 Example: To pass a value to the [@podium/context locale parser] it should be set
 on `request.app.params.locale` by a extension executed previously of this
 extension.
+
+## h.podiumSend(fragment)
+
+This method will wrap the provided fragment in a default [document template]
+before dispatching.
+
+See [document template] for further information.
 
 ## License
 
@@ -125,6 +132,7 @@ SOFTWARE.
 
 [@podium/context locale parser]: https://github.com/podium-lib/context#locale-1 '@podium/context locale parser'
 [Podium documentation]: https://podium-lib.io/ 'Podium documentation'
+[document template]: https://podium-lib.io/docs/api/document 'document template'
 [@podium/context]: https://github.com/podium-lib/context '@podium/context'
-[@podium/layout]: https://github.com/podium-lib/layout '@podium/layout'
+[@podium/layout]: https://podium-lib.io/docs/api/layout '@podium/layout'
 [hapi]: https://hapijs.com/ 'Hapi'

--- a/example/server.js
+++ b/example/server.js
@@ -2,7 +2,7 @@
 
 const HapiLayout = require('../');
 const Layout = require('@podium/layout');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const app = Hapi.Server({
     host: 'localhost',
@@ -13,7 +13,6 @@ const layout = new Layout({
     pathname: '/',
     logger: console,
     name: 'layout',
-
 });
 
 const podlet = layout.client.register({
@@ -29,11 +28,10 @@ app.register({
 app.route({
     method: 'GET',
     path: '/',
-    handler: (request, h) => {
-        const ctx = request.app.podium.context;
-        return Promise.all([podlet.fetch(ctx)]).then((result) => {
-            return `<html><body>${result[0]}</body></html>`
-        });
+    handler: async (request, h) => {
+        const incoming = request.app.podium;
+        const result = await podlet.fetch(incoming);
+        return h.podiumSend(result.content);
     },
 });
 

--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -1,15 +1,24 @@
 'use strict';
 
 const { HttpIncoming } = require('@podium/utils');
-const utils = require('@podium/utils');
 const pkg = require('../package.json');
-
-// Hapi v17 or newer
 
 const PodiumLayoutHapiPlugin = class PodiumLayoutHapiPlugin {
     constructor() {
+        Object.defineProperty(this, 'name', {
+            value: 'PodiumLayoutHapiPlugin',
+            enumerable: true,
+        });
+
         Object.defineProperty(this, 'pkg', {
             value: pkg,
+            enumerable: true,
+        });
+
+        Object.defineProperty(this, 'requirements', {
+            value: {
+                hapi: '>=17.0.0',
+            },
             enumerable: true,
         });
     }
@@ -26,38 +35,24 @@ const PodiumLayoutHapiPlugin = class PodiumLayoutHapiPlugin {
             method: async (request, h) => {
                 const { req, res } = request.raw;
                 const incoming = new HttpIncoming(req, res, request.app.params);
-                request.app.podium = await layout.context.process(incoming);
+                request.app.podium = await layout.process(incoming);
+
+                // If "incoming.proxy" is true, the proxy did proxy.
+                // Abandon the request.
+                if (request.app.podium.proxy) {
+                    return h.abandon;
+                }
+
+                // There was nothing to proxy. Continue the request.
                 return h.continue;
             },
         });
 
-        // Mount proxy route
-        const pathname = utils.pathnameBuilder(
-            layout.httpProxy.pathname,
-            layout.httpProxy.prefix,
-            '/{path*}',
-        );
-        server.route([
-            {
-                method: '*',
-                path: pathname,
-                handler: async (request, h) => {
-                    const incoming = await layout.httpProxy.process(
-                        request.app.podium,
-                    );
-
-                    // If a HttpIncoming object is returned, there was
-                    // nothing to proxy. Continue the request.
-                    if (incoming) {
-                        return h.continue;
-                    }
-
-                    // If "undefined" was not returned, the proxy did proxy.
-                    // Abandon the request.
-                    return h.abandon;
-                },
-            },
-        ]);
+        // Decorate response with .podiumSend() method
+        // eslint-disable-next-line func-names
+        server.decorate('toolkit', 'podiumSend', function(fragment) {
+            return layout.render(this.request.app.podium, fragment);
+        });
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -30,17 +30,18 @@
   },
   "author": "Trygve Lie",
   "dependencies": {
-    "@podium/utils": "3.1.2"
+    "@podium/utils": "4.0.0"
   },
   "devDependencies": {
+    "@hapi/hapi": "^18.1.0",
+    "@podium/layout": "4.0.0",
+    "@podium/test-utils": "1.5.0",
     "eslint": "^5.15.3",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-config-prettier": "^4.0.0",
+    "eslint-config-prettier": "^5.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-prettier": "^3.0.1",
     "prettier": "^1.16.1",
-    "tap": "^14.0.0",
-    "@podium/layout": "3.0.4",
-    "hapi": "^18.1.0"
+    "tap": "^14.0.0"
   }
 }

--- a/test/layout-plugin.js
+++ b/test/layout-plugin.js
@@ -1,7 +1,133 @@
 'use strict';
 
+const { PodletServer } = require('@podium/test-utils');
+const { URL } = require('url');
+const Layout = require('@podium/layout');
+const Hapi = require('@hapi/hapi');
+const http = require('http');
 const tap = require('tap');
-const Plugin = require('../');
+
+const HapiLayout = require('../');
+
+class Server {
+    constructor(options = {}, podletAddr) {
+        this.app = Hapi.Server({
+            host: 'localhost',
+            port: 0,
+        });
+
+        const layout = new Layout(
+            Object.assign(
+                {
+                    pathname: '/',
+                    name: 'layout',
+                },
+                options,
+            ),
+        );
+
+        layout.view((incoming, fragment) => {
+            return `## ${fragment} ##`;
+        });
+
+        const podlet = layout.client.register(podletAddr.options);
+
+        this.app.register({
+            plugin: new HapiLayout(),
+            options: layout,
+        });
+
+        this.app.route({
+            method: 'GET',
+            path: layout.pathname(),
+            handler: async (request, h) => {
+                const result = await podlet.fetch(request.app.podium);
+                return h.podiumSend(result.content);
+            },
+        });
+
+        // 404 route
+        this.app.route({
+            method: '*',
+            path: '/{any*}',
+            handler: (request, h) => {
+                const response = h.response('Not found');
+                response.code(404);
+                response.header('Content-Type', 'text/plain');
+                return response;
+            },
+        });
+    }
+
+    listen() {
+        return new Promise((resolve, reject) => {
+            setTimeout(async () => {
+                try {
+                    await this.app.start();
+                    resolve(this.app.info.uri);
+                } catch (error) {
+                    reject(error);
+                }
+            }, 100);
+        });
+    }
+
+    close() {
+        return new Promise(resolve => {
+            setTimeout(async () => {
+                await this.app.stop();
+                resolve();
+            }, 100);
+        });
+    }
+}
+
+const request = (
+    { pathname = '/', address = '', headers = {}, method = 'GET' } = {},
+    payload,
+) => {
+    return new Promise((resolve, reject) => {
+        const url = new URL(pathname, address);
+
+        if (method === 'POST' || method === 'PUT' || method === 'DELETE') {
+            headers = Object.assign(headers, {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Content-Length': Buffer.byteLength(payload),
+            });
+        }
+
+        const options = {
+            hostname: url.hostname,
+            port: url.port,
+            path: url.pathname,
+            headers,
+            method,
+        };
+
+        const req = http
+            .request(options, res => {
+                const chunks = [];
+                res.on('data', chunk => {
+                    chunks.push(chunk);
+                });
+                res.on('end', () => {
+                    resolve({
+                        headers: res.headers,
+                        body: chunks.join(''),
+                    });
+                });
+            })
+            .on('error', error => {
+                reject(error);
+            });
+
+        if (method === 'POST' || method === 'PUT' || method === 'DELETE') {
+            req.write(payload);
+        }
+
+        req.end();
+    });
+};
 
 /**
  * Constructor
@@ -10,11 +136,151 @@ const Plugin = require('../');
 tap.test(
     'Constructor() - object type - should be PodiumLayoutHapiPlugin',
     t => {
-        const p = new Plugin();
+        const layout = new HapiLayout();
         t.equal(
-            Object.prototype.toString.call(p),
+            Object.prototype.toString.call(layout),
             '[object PodiumLayoutHapiPlugin]',
         );
+        t.end();
+    },
+);
+
+/**
+ * Generic tests
+ */
+
+tap.test(
+    'request layout pathname - should fetch content from podlet and return content wrapped in a document template',
+    async t => {
+        const podlet = new PodletServer();
+        const service = await podlet.listen();
+
+        const layout = new Server({}, service);
+        const address = await layout.listen();
+
+        const result = await request({ address, pathname: '/' });
+        t.equal(result.body, '## <p>content component</p> ##');
+
+        await layout.close();
+        await podlet.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'request layout pathname - podlet is dead - should return fallback wrapped in a document template',
+    async t => {
+        const podlet = new PodletServer();
+        const service = await podlet.listen();
+
+        const layout = new Server({}, service);
+        const address = await layout.listen();
+
+        // Make sure layout has manifest
+        await request({ address, pathname: '/' });
+
+        // Kill podlet
+        await podlet.close();
+
+        const result = await request({ address, pathname: '/' });
+        t.equal(result.body, '## <p>fallback component</p> ##');
+
+        await layout.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'GET to "proxy" url - should proxy the request to the Podlets target endpoint',
+    async t => {
+        const podlet = new PodletServer();
+        const service = await podlet.listen();
+
+        const layout = new Server({}, service);
+        const address = await layout.listen();
+
+        // Make sure layout has manifest so proxy endpoints are mounted
+        await request({ address, pathname: '/' });
+
+        // Request proxy endpoint
+        const result = await request({
+            address,
+            method: 'GET',
+            pathname: '/podium-resource/component/localApi',
+        });
+
+        const body = JSON.parse(result.body);
+
+        t.equal(body.body, 'GET proxy target');
+
+        await layout.close();
+        await podlet.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'POST to "proxy" url - should proxy the request to the Podlets target endpoint',
+    async t => {
+        const podlet = new PodletServer();
+        const service = await podlet.listen();
+
+        const layout = new Server({}, service);
+        const address = await layout.listen();
+
+        // Make sure layout has manifest so proxy endpoints are mounted
+        await request({ address, pathname: '/' });
+
+        // Request proxy endpoint
+        const result = await request(
+            {
+                address,
+                method: 'POST',
+                pathname: '/podium-resource/component/localApi',
+            },
+            'proxy payload',
+        );
+
+        const body = JSON.parse(result.body);
+
+        t.equal(body.payload, 'proxy payload');
+        t.equal(body.body, 'POST proxy target');
+
+        await layout.close();
+        await podlet.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'PUT to "proxy" url - should proxy the request to the Podlets target endpoint',
+    async t => {
+        const podlet = new PodletServer();
+        const service = await podlet.listen();
+
+        const layout = new Server({}, service);
+        const address = await layout.listen();
+
+        // Make sure layout has manifest so proxy endpoints are mounted
+        await request({ address, pathname: '/' });
+
+        // Request proxy endpoint
+        const result = await request(
+            {
+                address,
+                method: 'PUT',
+                pathname: '/podium-resource/component/localApi',
+            },
+            'proxy payload',
+        );
+
+        const body = JSON.parse(result.body);
+
+        t.equal(body.payload, 'proxy payload');
+        t.equal(body.body, 'PUT proxy target');
+
+        await layout.close();
+        await podlet.close();
         t.end();
     },
 );


### PR DESCRIPTION
This updates this module to support Podium v4.

Most significent change here is that it does now contain integration tests which tests the life cycle of interacting with a Podlet. These tests are written so they can be reused to test the Fastify plugin (and others) also.