### PR TITLE
Support Hapi v19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [12.x, 13.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Hapi plugin for @podium/layout.
 
-[![Dependencies](https://img.shields.io/david/podium-lib/hapi-layout.svg?style=flat-square)](https://david-dm.org/podium-lib/hapi-layout)
-[![Build Status](https://travis-ci.org/podium-lib/hapi-layout.svg?branch=master&style=flat-square)](https://travis-ci.org/podium-lib/hapi-layout)
-[![Greenkeeper badge](https://badges.greenkeeper.io/podium-lib/hapi-layout.svg?style=flat-square)](https://greenkeeper.io/)
-[![Known Vulnerabilities](https://snyk.io/test/github/podium-lib/hapi-layout/badge.svg?style=flat-square)](https://snyk.io/test/github/podium-lib/hapi-layout)
+[![Dependencies](https://img.shields.io/david/podium-lib/hapi-layout.svg)](https://david-dm.org/podium-lib/hapi-layout)
+[![GitHub Actions status](https://github.com/podium-lib/hapi-layout/workflows/Run%20Lint%20and%20Tests/badge.svg)](https://github.com/podium-lib/hapi-layout/actions?query=workflow%3A%22Run+Lint+and+Tests%22)
+[![Known Vulnerabilities](https://snyk.io/test/github/podium-lib/hapi-layout/badge.svg)](https://snyk.io/test/github/podium-lib/hapi-layout)
 
 Module for building [@podium/layout] servers with [hapi]. For writing layouts,
 please see the [Podium documentation].
@@ -18,7 +17,8 @@ $ npm install @podium/hapi-layout
 
 ## Requirements
 
-This module require Hapi v17 or newer.
+The v3.x of this module require Hapi v19 or newer and node v12 or newer. Please
+use v2.x of this module for Hapi v18 or older.
 
 ## Simple usage
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "@podium/utils": "4.1.2"
   },
   "devDependencies": {
-    "@hapi/hapi": "18.4.0",
-    "@podium/layout": "4.2.8",
+    "@hapi/hapi": "19.1.0",
+    "@podium/layout": "4.3.1",
     "@podium/test-utils": "2.0.0",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.0.0",
@@ -42,6 +42,6 @@
     "eslint-plugin-import": "2.20.1",
     "eslint-plugin-prettier": "3.1.2",
     "prettier": "1.19.1",
-    "tap": "14.10.5"
+    "tap": "14.10.6"
   }
 }


### PR DESCRIPTION
Hapi v19 dropped support for node v10 and older. This adjusts for supporting Hapi v19.

This must be published as a new major version.